### PR TITLE
refact: query 최적화 및 코드 구조 개선 작업

### DIFF
--- a/src/main/java/hashsnap/global/response/ApiResponse.java
+++ b/src/main/java/hashsnap/global/response/ApiResponse.java
@@ -5,6 +5,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 공통 API 응답 DTO
+ * 모든 REST API의 표준 응답 형식 제공
+ * 성공/실패, 메시지, 데이터를 포함한 일관된 응답 구조
+ *
+ * @param <T> 응답 데이터 타입
+ */
 @Data
 @Builder
 @NoArgsConstructor

--- a/src/main/java/hashsnap/global/util/JwtUtil.java
+++ b/src/main/java/hashsnap/global/util/JwtUtil.java
@@ -11,6 +11,11 @@ import org.springframework.stereotype.Component;
 import java.util.Base64;
 import java.util.Date;
 
+/**
+ * JWT 토큰 유틸리티 클래스
+ * Access/Refresh Token 생성, 검증, 파싱 기능 제공
+ * JJWT 라이브러리 기반 토큰 관리 및 만료 시간 검증
+ */
 @Component
 public class JwtUtil {
 

--- a/src/main/java/hashsnap/global/util/ResponseUtils.java
+++ b/src/main/java/hashsnap/global/util/ResponseUtils.java
@@ -4,6 +4,15 @@ import hashsnap.global.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+/**
+ * JWT 인증 필터
+ * HTTP 요청의 Authorization 헤더에서 JWT를 추출하고 검증
+ * 인증된 사용자 정보로 SecurityContext에 Authentication 등록
+ *
+ * 유효한 JWT가 있는 경우에만 인증 처리를 수행하며,
+ * 이후 필터 체인에서 인증된 사용자로 요청을 이어감
+ */
+
 public class ResponseUtils {
     // 성공 응답들
     public static <T> ResponseEntity<ApiResponse<T>> ok(String message) {

--- a/src/main/java/hashsnap/login/conifg/JwtAuthenticationFilter.java
+++ b/src/main/java/hashsnap/login/conifg/JwtAuthenticationFilter.java
@@ -13,6 +13,12 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+/**
+ * JWT 인증 필터
+ *
+ * HTTP 요청에서 JWT 토큰을 추출하고, 유효한 경우 사용자 인증을 수행하여
+ * SecurityContext에 등록함.
+ */
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter{

--- a/src/main/java/hashsnap/login/conifg/JwtFilterConfig.java
+++ b/src/main/java/hashsnap/login/conifg/JwtFilterConfig.java
@@ -5,6 +5,11 @@ import hashsnap.login.service.UserAuthenticationService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * JWT 필터 설정 클래스
+ * JwtAuthenticationFilter Bean 등록
+ * Spring Security와 JWT 유틸 간 순환 참조 문제 해결
+ */
 @Configuration
 public class JwtFilterConfig {
 

--- a/src/main/java/hashsnap/login/conifg/SecurityConfig.java
+++ b/src/main/java/hashsnap/login/conifg/SecurityConfig.java
@@ -17,6 +17,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 
+/**
+ * Spring Security 보안 설정
+ * JWT 인증 필터 체인 구성 및 URL별 접근 권한 설정
+ * CSRF 보호, CORS 설정, 폼 로그인 비활성화 등 API 서버 최적화
+ */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {

--- a/src/main/java/hashsnap/login/controller/AuthController.java
+++ b/src/main/java/hashsnap/login/controller/AuthController.java
@@ -3,23 +3,32 @@ package hashsnap.login.controller;
 import hashsnap.global.controller.ApiController;
 import hashsnap.global.response.ApiResponse;
 import hashsnap.global.util.ResponseUtils;
+import hashsnap.login.dto.EmailVerificationDto;
 import hashsnap.login.dto.LoginRequest;
 import hashsnap.login.dto.LoginResponseDto;
 import hashsnap.login.dto.TokenRefreshResponseDto;
+import hashsnap.login.exception.EmailVerificationException;
+import hashsnap.login.exception.EmailVerificationException;
 import hashsnap.login.service.AuthService;
+import hashsnap.login.service.EmailVerificationService;
+import hashsnap.login.service.UserService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 public class AuthController extends ApiController {
 
     private final AuthService authService;
+    private final UserService userService;
+    private final EmailVerificationService emailVerificationService;
 
     /**
      * 로그인 API
@@ -82,6 +91,66 @@ public class AuthController extends ApiController {
         removeRefreshTokenCookie(response);
 
         return ResponseUtils.ok("로그아웃이 완료되었습니다");
+    }
+
+    /**
+     * 이메일 인증 API( 인증번호 발송, 인증번호 확인 )
+     * @param request 이메일 인증 DTO
+     * @return result message
+     */
+    @PostMapping("/auth/email-verification")
+    public ResponseEntity<ApiResponse<Void>> handleEmailVerification(@Valid @RequestBody EmailVerificationDto request) {
+        try {
+            return switch (request.getAction()) {
+                case "send" -> handleSendAction(request);
+                case "verify" -> handleVerifyAction(request);
+                default -> ResponseUtils.badRequest("잘못된 요청입니다");
+            };
+        } catch (EmailVerificationException e) {
+            return ResponseUtils.badRequest(e.getMessage());
+        } catch (Exception e) {
+            log.error("이메일 인증 처리 중 오류 발생", e);
+            return ResponseUtils.internalServerError("처리 중 오류가 발생했습니다");
+        }
+    }
+
+    /**
+     * 이메일 인증 헬퍼 메서드
+     * case: 'send'
+     * 인증번호 전송
+     * @param request 이메일 인증 DTO
+     * @return result message
+     */
+    private ResponseEntity<ApiResponse<Void>> handleSendAction(EmailVerificationDto request) {
+        if ("password-reset".equals(request.getPurpose()) && !userService.isEmailExists(request.getEmail())) {
+            return ResponseUtils.badRequest("존재하지 않는 메일입니다");
+        }
+
+        emailVerificationService.sendVerificationCode(request.getEmail(), request.getPurpose());
+        return ResponseUtils.ok("인증번호가 발송되었습니다");
+    }
+
+    /**
+     * 이메일 인증 헬퍼 메서드
+     * case: 'verify'
+     * 인증번호 검증
+     * @param request 이메일 인증 DTO
+     * @return result message
+     */
+    private ResponseEntity<ApiResponse<Void>> handleVerifyAction(EmailVerificationDto request) {
+        if (request.getVerificationCode() == null || request.getVerificationCode().trim().isEmpty()) {
+            return ResponseUtils.badRequest("인증번호를 입력해주세요");
+        }
+
+        boolean isValid = emailVerificationService.verifyCode(
+                request.getEmail(),
+                request.getVerificationCode().trim(),
+                request.getPurpose()
+        );
+
+        return isValid
+                ? ResponseUtils.ok("인증이 완료되었습니다")
+                : ResponseUtils.badRequest("인증번호가 일치하지 않습니다");
     }
 
     // === 쿠키 관련 헬퍼 메서드들 (Controller 책임) ===

--- a/src/main/java/hashsnap/login/controller/AuthController.java
+++ b/src/main/java/hashsnap/login/controller/AuthController.java
@@ -4,10 +4,9 @@ import hashsnap.global.controller.ApiController;
 import hashsnap.global.response.ApiResponse;
 import hashsnap.global.util.ResponseUtils;
 import hashsnap.login.dto.EmailVerificationDto;
-import hashsnap.login.dto.LoginRequest;
+import hashsnap.login.dto.LoginRequestDto;
 import hashsnap.login.dto.LoginResponseDto;
 import hashsnap.login.dto.TokenRefreshResponseDto;
-import hashsnap.login.exception.EmailVerificationException;
 import hashsnap.login.exception.EmailVerificationException;
 import hashsnap.login.service.AuthService;
 import hashsnap.login.service.EmailVerificationService;
@@ -21,6 +20,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 인증 API 컨트롤러
+ * JWT 기반 로그인, 토큰 갱신, 로그아웃 처리, 이메일 인증
+ * HttpOnly 쿠키를 통한 안전한 RefreshToken 관리
+ */
 @RestController
 @Slf4j
 @RequiredArgsConstructor
@@ -32,16 +36,16 @@ public class AuthController extends ApiController {
 
     /**
      * 로그인 API
-     * @param loginRequest 로그인 요청 DTO
+     * @param loginRequestDto 로그인 요청 DTO
      * @param response Refresh Token을 HttpOnly 쿠키로 설정 목적
      * @return response message
      */
     @PostMapping("/auth/login")
     public ResponseEntity<ApiResponse<LoginResponseDto>> login(
-            @Valid @RequestBody LoginRequest loginRequest,
+            @Valid @RequestBody LoginRequestDto loginRequestDto,
             HttpServletResponse response) {
 
-        LoginResponseDto loginResponse = authService.login(loginRequest);
+        LoginResponseDto loginResponse = authService.login(loginRequestDto);
 
         // Refresh Token을 HttpOnly 쿠키에 저장 (보안상 응답에서 제외)
         addRefreshTokenCookie(response, loginResponse.getRefreshToken());

--- a/src/main/java/hashsnap/login/controller/PageController.java
+++ b/src/main/java/hashsnap/login/controller/PageController.java
@@ -6,7 +6,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 /**
- * Thymeleaf 뷰 반환 페이지 컨트롤러
+ * 페이지 라우팅 컨트롤러
+ * Thymeleaf 뷰 템플릿을 반환하는 페이지 네비게이션 담당
+ * JWT 토큰 기반 클라이언트 사이드 라우팅 지원
  */
 @Controller
 public class PageController {

--- a/src/main/java/hashsnap/login/controller/UserController.java
+++ b/src/main/java/hashsnap/login/controller/UserController.java
@@ -4,9 +4,6 @@ import hashsnap.global.controller.ApiController;
 import hashsnap.global.response.ApiResponse;
 import hashsnap.global.util.ResponseUtils;
 import hashsnap.login.dto.*;
-import hashsnap.login.entity.User;
-import hashsnap.login.exception.EmailVerificationException;
-import hashsnap.login.service.EmailVerificationService;
 import hashsnap.login.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,16 +11,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
 
-
-@RestController  // JSON 반환
+@RestController
 @Slf4j
 @RequiredArgsConstructor
 public class UserController extends ApiController {
 
     private final UserService userService;
-    private final EmailVerificationService emailVerificationService;
 
     /**
      * 이메일 중복 확인 API
@@ -53,20 +47,12 @@ public class UserController extends ApiController {
     /**
      * 유저 프로필 조회 API
      * @param email 유저 이메일
-     * @return map: UserInfoResponseDto -> comment. 반환 형식 수정하는게 좋을 듯
+     * @return UserInfoResponseDto
      */
-    @GetMapping("/users/profile")
-    public ResponseEntity<ApiResponse<Map<String, UserInfoResponseDto>>> getUserProfile(@RequestParam String email) {
-        User user = userService.findByEmail(email);
-
-        if (user == null) {
-            return ResponseUtils.notFound("사용자를 찾을 수 없습니다");
-        }
-
-        UserInfoResponseDto userInfo = UserInfoResponseDto.from(user);
-        Map<String, UserInfoResponseDto> data = Map.of("user", userInfo);
-
-        return ResponseUtils.ok("사용자 정보 조회 성공", data);
+    @GetMapping("users/profile")
+    public ResponseEntity<ApiResponse<UserInfoResponseDto>> getUserProfile(@RequestParam String email) {
+        UserInfoResponseDto userInfo = userService.getUserInfo(email);
+        return ResponseUtils.ok("사용자 정보 조회 성공", userInfo);
     }
 
     /**
@@ -76,77 +62,9 @@ public class UserController extends ApiController {
      */
     @PutMapping("/users/password")
     public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody PasswordResetDto request) {
-        try {
-            if (!emailVerificationService.isEmailVerified(request.getEmail(), "password-reset")) {
-                return ResponseUtils.badRequest("이메일 인증이 완료되지 않았습니다");
-            }
-
-            userService.resetPassword(request.getEmail(), request.getNewPassword());
-            return ResponseUtils.ok("비밀번호가 성공적으로 재설정되었습니다");
-
-        } catch (Exception e) {
-            log.error("비밀번호 재설정 중 오류 발생", e);
-            return ResponseUtils.internalServerError("비밀번호 재설정 중 오류가 발생했습니다");
-        }
+        userService.resetPassword(request.getEmail(), request.getNewPassword());
+        return ResponseUtils.ok("비밀번호가 성공적으로 재설정되었습니다");
     }
 
-    /**
-     * 이메일 인증 API( 인증번호 발송, 인증번호 확인 )
-     * @param request 이메일 인증 DTO
-     * @return result message
-     */
-    @PostMapping("/auth/email-verification")
-    public ResponseEntity<ApiResponse<Void>> handleEmailVerification(@Valid @RequestBody EmailVerificationDto request) {
-        try {
-            return switch (request.getAction()) {
-                case "send" -> handleSendAction(request);
-                case "verify" -> handleVerifyAction(request);
-                default -> ResponseUtils.badRequest("잘못된 요청입니다");
-            };
-        } catch (EmailVerificationException e) {
-            return ResponseUtils.badRequest(e.getMessage());
-        } catch (Exception e) {
-            log.error("이메일 인증 처리 중 오류 발생", e);
-            return ResponseUtils.internalServerError("처리 중 오류가 발생했습니다");
-        }
-    }
 
-    /**
-     * 이메일 인증 헬퍼 메서드
-     * case: 'send'
-     * 인증번호 전송
-     * @param request 이메일 인증 DTO
-     * @return result message
-     */
-    private ResponseEntity<ApiResponse<Void>> handleSendAction(EmailVerificationDto request) {
-        if ("password-reset".equals(request.getPurpose()) && !userService.isEmailExists(request.getEmail())) {
-            return ResponseUtils.badRequest("존재하지 않는 메일입니다");
-        }
-
-        emailVerificationService.sendVerificationCode(request.getEmail(), request.getPurpose());
-        return ResponseUtils.ok("인증번호가 발송되었습니다");
-    }
-
-    /**
-     * 이메일 인증 헬퍼 메서드
-     * case: 'verify'
-     * 인증번호 검증
-     * @param request 이메일 인증 DTO
-     * @return result message
-     */
-    private ResponseEntity<ApiResponse<Void>> handleVerifyAction(EmailVerificationDto request) {
-        if (request.getVerificationCode() == null || request.getVerificationCode().trim().isEmpty()) {
-            return ResponseUtils.badRequest("인증번호를 입력해주세요");
-        }
-
-        boolean isValid = emailVerificationService.verifyCode(
-                request.getEmail(),
-                request.getVerificationCode().trim(),
-                request.getPurpose()
-        );
-
-        return isValid
-                ? ResponseUtils.ok("인증이 완료되었습니다")
-                : ResponseUtils.badRequest("인증번호가 일치하지 않습니다");
-    }
 }

--- a/src/main/java/hashsnap/login/controller/UserController.java
+++ b/src/main/java/hashsnap/login/controller/UserController.java
@@ -11,7 +11,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
+/**
+ * 사용자 관리 API 컨트롤러
+ * 회원가입, 프로필 조회, 비밀번호 재설정 등
+ * 사용자 관련 모든 REST API 엔드포인트 제공
+ */
 @RestController
 @Slf4j
 @RequiredArgsConstructor
@@ -25,9 +29,9 @@ public class UserController extends ApiController {
      * @return EmailCheckResponse
      */
     @GetMapping("/users")
-    public ResponseEntity<ApiResponse<EmailCheckResponse>> checkEmailDuplicate(@RequestParam String email) {
+    public ResponseEntity<ApiResponse<EmailCheckResponseDto>> checkEmailDuplicate(@RequestParam String email) {
         boolean exists = userService.isEmailExists(email);
-        EmailCheckResponse response = EmailCheckResponse.builder()
+        EmailCheckResponseDto response = EmailCheckResponseDto.builder()
                 .exists(exists)
                 .build();
         return ResponseUtils.ok("이메일 중복 확인 완료", response);

--- a/src/main/java/hashsnap/login/dto/EmailCheckResponseDto.java
+++ b/src/main/java/hashsnap/login/dto/EmailCheckResponseDto.java
@@ -5,10 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 이메일 중복 체크 응답 DTO
+ * 이메일이 이미 존재하면 true, 존재하지 않으면 false 값을 갖는다.
+ */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class EmailCheckResponse {
+public class EmailCheckResponseDto {
     private boolean exists;
 }

--- a/src/main/java/hashsnap/login/dto/EmailVerificationDto.java
+++ b/src/main/java/hashsnap/login/dto/EmailVerificationDto.java
@@ -6,6 +6,17 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 이메일 인증 요청 DTO
+ *
+ * 이메일 인증 절차에서 사용되는 요청 데이터 객체입니다.
+ * 인증 코드 전송(send) 또는 인증 코드 검증(verify) 요청에 사용됩니다.
+ *
+ * - action: "send" 또는 "verify" 중 하나
+ * - purpose: 인증 목적 ("signup" 또는 "findPwd")
+ * - email: 대상 이메일 주소
+ * - verificationCode: 인증 코드 (verify 요청 시 필수)
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hashsnap/login/dto/LoginRequestDto.java
+++ b/src/main/java/hashsnap/login/dto/LoginRequestDto.java
@@ -5,11 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 로그인 API 요청 DTO
+ */
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class LoginRequest{
+public class LoginRequestDto {
     private String email;
     private String password;
 }

--- a/src/main/java/hashsnap/login/dto/LoginResponseDto.java
+++ b/src/main/java/hashsnap/login/dto/LoginResponseDto.java
@@ -3,6 +3,9 @@ package hashsnap.login.dto;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * 로그인 API 응답 DTO
+ */
 @Data
 @Builder
 public class LoginResponseDto {

--- a/src/main/java/hashsnap/login/dto/PasswordResetDto.java
+++ b/src/main/java/hashsnap/login/dto/PasswordResetDto.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 비밀번호 변경 요청 DTO
+ */
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/hashsnap/login/dto/SignupRequestDto.java
+++ b/src/main/java/hashsnap/login/dto/SignupRequestDto.java
@@ -8,6 +8,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 회원가입 요청 DTO
+ * 사용자 등록 시 필요한 정보 전달
+ * Bean Validation 어노테이션을 통한 입력값 검증 포함
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/hashsnap/login/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/hashsnap/login/dto/TokenRefreshResponseDto.java
@@ -3,6 +3,9 @@ package hashsnap.login.dto;
 import lombok.Builder;
 import lombok.Data;
 
+/**
+ * Token 발급 요청 DTO
+ */
 @Data
 @Builder
 public class TokenRefreshResponseDto {

--- a/src/main/java/hashsnap/login/dto/UserInfoResponseDto.java
+++ b/src/main/java/hashsnap/login/dto/UserInfoResponseDto.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 유저 정보 응답 DTO
+ * 로그인된 사용자의 프로필 정보 조회 시 사용
+ * 민감한 정보(비밀번호) 제외하고 반환
+ */
 @Data
 @Builder
 @NoArgsConstructor

--- a/src/main/java/hashsnap/login/dto/UserStatusResponse.java
+++ b/src/main/java/hashsnap/login/dto/UserStatusResponse.java
@@ -1,0 +1,11 @@
+package hashsnap.login.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class UserStatusResponse {
+    private String email;
+    private boolean isActive;
+}

--- a/src/main/java/hashsnap/login/dto/UserStatusResponseDto.java
+++ b/src/main/java/hashsnap/login/dto/UserStatusResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 
 @Data
 @Builder
-public class UserStatusResponse {
+public class UserStatusResponseDto {
     private String email;
     private boolean isActive;
 }

--- a/src/main/java/hashsnap/login/repository/UserRepository.java
+++ b/src/main/java/hashsnap/login/repository/UserRepository.java
@@ -8,10 +8,21 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
+    /**
+     * 전체 회원 중 이메일로 사용자 조회
+     * (계정 상태와 활성화 여부 무관)
+     */
     Optional<User> findByEmail(String email);
 
+    /**
+     * 활성 상태이고 활성화된 사용자 중 이메일로 조회
+     * (정지 또는 비활성 사용자 제외)
+     */
     @Query("SELECT u FROM User u WHERE u.email = :email AND u.status = 'ACTIVE' AND u.enabled = true")
     Optional<User> findActiveUserByEmail(@Param("email") String email);
 
+    /**
+     * 이메일 중복 여부 확인
+     */
     boolean existsByEmail(String email);
 }

--- a/src/main/java/hashsnap/login/repository/UserRepository.java
+++ b/src/main/java/hashsnap/login/repository/UserRepository.java
@@ -2,11 +2,16 @@ package hashsnap.login.repository;
 
 import hashsnap.login.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email AND u.status = 'ACTIVE' AND u.enabled = true")
+    Optional<User> findActiveUserByEmail(@Param("email") String email);
 
     boolean existsByEmail(String email);
 }

--- a/src/main/java/hashsnap/login/service/AuthService.java
+++ b/src/main/java/hashsnap/login/service/AuthService.java
@@ -1,7 +1,7 @@
 package hashsnap.login.service;
 
 import hashsnap.global.util.JwtUtil;
-import hashsnap.login.dto.LoginRequest;
+import hashsnap.login.dto.LoginRequestDto;
 import hashsnap.login.dto.LoginResponseDto;
 import hashsnap.login.entity.User;
 import hashsnap.login.exception.AuthException;
@@ -13,6 +13,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+/**
+ * 인증 비즈니스 로직 서비스
+ * Spring Security 기반 사용자 인증 및 JWT 토큰 관리
+ * 로그인, 토큰 갱신, 로그아웃 프로세스 담당
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -26,8 +31,8 @@ public class AuthService {
     /**
      * 로그인 처리
      */
-    public LoginResponseDto login(LoginRequest loginRequest) {
-        String email = loginRequest.getEmail();
+    public LoginResponseDto login(LoginRequestDto loginRequestDto) {
+        String email = loginRequestDto.getEmail();
 
         try {
             // 1. 로그인 시도 전 계정 잠금 상태 확인
@@ -39,8 +44,8 @@ public class AuthService {
             // 2. 인증 시도
             Authentication authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(
-                            loginRequest.getEmail(),
-                            loginRequest.getPassword()
+                            loginRequestDto.getEmail(),
+                            loginRequestDto.getPassword()
                     )
             );
 

--- a/src/main/java/hashsnap/login/service/EmailVerificationService.java
+++ b/src/main/java/hashsnap/login/service/EmailVerificationService.java
@@ -11,6 +11,11 @@ import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+/**
+ * 이메일 인증 서비스
+ * JavaMailSender 기반 인증번호 발송 및 검증
+ * HttpSession을 활용한 임시 인증 상태 관리 (5분 만료)
+ */
 @Service
 @RequiredArgsConstructor
 public class EmailVerificationService {

--- a/src/main/java/hashsnap/login/service/RefreshTokenService.java
+++ b/src/main/java/hashsnap/login/service/RefreshTokenService.java
@@ -11,6 +11,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
+/**
+ * 리프레시 토큰 관리 서비스
+ * 사용자별 RefreshToken DB 저장, 검증, 삭제 처리
+ * JWT 토큰 갱신 시 보안 검증 담당
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/hashsnap/login/service/RefreshTokenService.java
+++ b/src/main/java/hashsnap/login/service/RefreshTokenService.java
@@ -41,7 +41,7 @@ public class RefreshTokenService {
         }
 
         try {
-            User user = userRepository.findByEmail(email)
+            User user = userRepository.findActiveUserByEmail(email)
                     .orElseThrow(() -> {
                         log.warn("사용자를 찾을 수 없음: email={}", email);
                         return new UserNotFoundException("사용자를 찾을 수 없습니다: " + email);
@@ -79,7 +79,7 @@ public class RefreshTokenService {
         }
 
         try {
-            User user = userRepository.findByEmail(email)
+            User user = userRepository.findActiveUserByEmail(email)
                     .orElseThrow(() -> {
                         log.warn("사용자를 찾을 수 없음: email={}", email);
                         return new UserNotFoundException("사용자를 찾을 수 없습니다: " + email);
@@ -119,7 +119,7 @@ public class RefreshTokenService {
         }
 
         try {
-            User user = userRepository.findByEmail(email)
+            User user = userRepository.findActiveUserByEmail(email)
                     .orElseThrow(() -> {
                         log.warn("사용자를 찾을 수 없음: email={}", email);
                         return new UserNotFoundException("사용자를 찾을 수 없습니다: " + email);
@@ -150,7 +150,7 @@ public class RefreshTokenService {
         }
 
         try {
-            User user = userRepository.findByEmail(email)
+            User user = userRepository.findActiveUserByEmail(email)
                     .orElseThrow(() -> {
                         log.warn("사용자를 찾을 수 없음: email={}", email);
                         return new UserNotFoundException("사용자를 찾을 수 없습니다: " + email);

--- a/src/main/java/hashsnap/login/service/UserAuthenticationService.java
+++ b/src/main/java/hashsnap/login/service/UserAuthenticationService.java
@@ -1,12 +1,17 @@
 package hashsnap.login.service;
 
 import hashsnap.login.entity.User;
-import hashsnap.login.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+/**
+ * Spring Security용 사용자 인증 서비스
+ * 이메일로 사용자를 조회하고 UserDetails 객체로 변환하여 반환
+ * 모든 사용자에게 기본적으로 ROLE_USER 권한을 부여함
+ */
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/hashsnap/login/service/UserService.java
+++ b/src/main/java/hashsnap/login/service/UserService.java
@@ -73,7 +73,7 @@ public class UserService {
             throw new IllegalArgumentException("이메일은 필수입니다");
         }
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findActiveUserByEmail(email)
                 .orElseThrow(() -> {
                     log.warn("사용자를 찾을 수 없음: email={}", email);
                     return new UsernameNotFoundException("사용자를 찾을 수 없습니다");

--- a/src/main/java/hashsnap/login/service/UserService.java
+++ b/src/main/java/hashsnap/login/service/UserService.java
@@ -1,6 +1,7 @@
 package hashsnap.login.service;
 
 import hashsnap.login.dto.SignupRequestDto;
+import hashsnap.login.dto.UserInfoResponseDto;
 import hashsnap.login.entity.User;
 import hashsnap.login.repository.UserRepository;
 import hashsnap.login.exception.EmailVerificationException;
@@ -30,24 +31,25 @@ public class UserService {
      */
     @Transactional
     public void signup(@Valid SignupRequestDto signupRequest) {
+        log.info("회원가입 시작: email={}", signupRequest.getEmail());
+
         // 1. 이메일 인증 확인
         if (!emailVerificationService.isEmailVerified(signupRequest.getEmail(), "signup")) {
+            log.warn("이메일 인증 미완료: email={}", signupRequest.getEmail());
             throw new EmailVerificationException("이메일 인증을 완료해주세요");
         }
 
         // 2. 중복 사용자 확인
         if (userRepository.existsByEmail(signupRequest.getEmail())) {
+            log.warn("이메일 중복: email={}", signupRequest.getEmail());
             throw new DuplicateUserException("이미 존재하는 이메일입니다");
         }
 
         // 3. 비밀번호 암호화
-        // 원본 비밀번호
-        String rawPassword = signupRequest.getPassword();
-        // 원본 비밀번호를 암호화
-        String encodedPassword = passwordEncoder.encode(rawPassword);
+        String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
 
         // 4. 사용자 저장
-        User user =  User.builder()
+        User user = User.builder()
                 .username(signupRequest.getUsername())
                 .nickname(signupRequest.getNickname())
                 .password(encodedPassword)
@@ -57,73 +59,117 @@ public class UserService {
                 .build();
 
         userRepository.save(user);
+        log.info("회원가입 완료: email={}", signupRequest.getEmail());
     }
 
     /**
-     * 유저 정보 조회
+     * 사용자 정보 조회 (응답 DTO로 반환)
+     */
+    public UserInfoResponseDto getUserInfo(String email) {
+        log.debug("사용자 정보 조회: email={}", email);
+
+        if (email == null || email.trim().isEmpty()) {
+            log.warn("이메일이 null 또는 비어있음");
+            throw new IllegalArgumentException("이메일은 필수입니다");
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: email={}", email);
+                    return new UsernameNotFoundException("사용자를 찾을 수 없습니다");
+                });
+
+        log.debug("사용자 정보 조회 완료: email={}", email);
+        return UserInfoResponseDto.from(user);
+    }
+
+    /**
+     * 사용자 엔티티 조회 (내부 사용용)
      */
     public User findByEmail(String email) {
-        // JPA로 사용자 조회
+        if (email == null || email.trim().isEmpty()) {
+            log.warn("이메일이 null 또는 비어있음");
+            throw new IllegalArgumentException("이메일은 필수입니다");
+        }
+
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
+                .orElseThrow(() -> {
+                    log.warn("사용자를 찾을 수 없음: email={}", email);
+                    return new UsernameNotFoundException("사용자를 찾을 수 없습니다");
+                });
     }
 
     /**
-     * 이메일 중복 조회
+     * 이메일 중복 확인
      */
     public boolean isEmailExists(String email) {
-
+        if (email == null || email.trim().isEmpty()) {
+            return false;
+        }
         return userRepository.existsByEmail(email);
     }
 
     /**
-     * 비밀번호 업데이트
+     * 비밀번호 재설정
      */
     @Transactional
-    public void resetPassword(@NotBlank(message = "이메일을 입력해주세요") @Email(message = "올바른 이메일 형식이 아닙니다") String email,
+    public void resetPassword(@NotBlank(message = "이메일을 입력해주세요")
+                              @Email(message = "올바른 이메일 형식이 아닙니다") String email,
                               @NotBlank(message = "새 비밀번호를 입력해주세요")
                               @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다") String newPassword) {
+
+        log.info("비밀번호 재설정 시작: email={}", email);
+
+        // 이메일 인증 확인
+        if (!emailVerificationService.isEmailVerified(email, "password-reset")) {
+            log.warn("이메일 인증 미완료: email={}", email);
+            throw new EmailVerificationException("이메일 인증을 완료해주세요");
+        }
+
+        User user = findByEmail(email);
+
         // 새로운 비밀번호를 암호화
         String encodedPassword = passwordEncoder.encode(newPassword);
 
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + email));
-
         user.setLoginFailureCount(0);
-        user.setPassword(encodedPassword); //update
+        user.setPassword(encodedPassword);
+
+        log.info("비밀번호 재설정 완료: email={}", email);
     }
 
     /**
-     * 계정 잠금
+     * 로그인 실패 카운트 리셋
      */
     @Transactional
     public void resetLoginFailureCount(String email) {
+        log.debug("로그인 실패 카운트 리셋: email={}", email);
+
         User user = findByEmail(email);
-        if (user != null && user.getLoginFailureCount() > 0) {
+        if (user.getLoginFailureCount() > 0) {
             user.setLoginFailureCount(0);
-            userRepository.save(user);
-            log.info("로그인 실패 카운트 리셋: {}", email);
+            log.info("로그인 실패 카운트 리셋 완료: email={}", email);
         }
     }
 
     /**
-     * 로그인 실패 카운트
+     * 로그인 실패 카운트 증가
      */
     @Transactional
     public void incrementLoginFailureCount(String email) {
+        log.debug("로그인 실패 카운트 증가: email={}", email);
+
         User user = findByEmail(email);
-        if (user != null) {
-            int newCount = user.getLoginFailureCount() + 1;
+        int newCount = user.getLoginFailureCount() + 1;
 
-            // 5회 이상 실패 시 계정 잠금
-            if (newCount >= 5) {
-                user.setStatus(User.UserStatus.SUSPENDED);
-                user.setEnabled(false);
-                log.warn("계정 잠금 처리: {} (실패 횟수: {})", email, newCount);
-            }
-
-            user.setLoginFailureCount(newCount);
-            userRepository.save(user);
+        // 5회 이상 실패 시 계정 잠금
+        if (newCount >= 5) {
+            user.setStatus(User.UserStatus.SUSPENDED);
+            user.setEnabled(false);
+            log.warn("계정 잠금 처리: email={}, 실패횟수={}", email, newCount);
         }
+
+        user.setLoginFailureCount(newCount);
+        log.info("로그인 실패 카운트 업데이트: email={}, count={}", email, newCount);
     }
+
 }

--- a/src/main/java/hashsnap/login/service/UserService.java
+++ b/src/main/java/hashsnap/login/service/UserService.java
@@ -17,6 +17,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 사용자 비즈니스 로직 서비스
+ * 회원가입, 사용자 조회, 비밀번호 관리 등 핵심 비즈니스 로직 처리
+ * BCrypt 암호화 및 이메일 인증 검증 포함
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/hashsnap/login/service/UserService.java
+++ b/src/main/java/hashsnap/login/service/UserService.java
@@ -132,6 +132,7 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(newPassword);
 
         user.setLoginFailureCount(0);
+        user.setStatus(User.UserStatus.ACTIVE);
         user.setPassword(encodedPassword);
 
         log.info("비밀번호 재설정 완료: email={}", email);

--- a/src/main/resources/templates/userPage.html
+++ b/src/main/resources/templates/userPage.html
@@ -116,7 +116,7 @@
             })
             .then(data => {
                 if (data && data.success) {
-                    displayUserInfo(data.data.user);
+                    displayUserInfo(data.data);
                 } else {
                     showError(data?.message || '사용자 정보를 불러오는데 실패했습니다.');
                 }


### PR DESCRIPTION
## 🔧 \[개선 제안] 활성 사용자 조회 로직 분리

### ✅ 배경

현재 `UserService`, `RefreshTokenService` 등에서 사용자 정보를 조회할 때, `findByEmail(email)`을 사용하여 **활성/비활성 사용자 구분 없이 전체 조회**하고 있음.

그러나 실제로는 아래 조건을 만족하는 사용자만 유효한 작업(로그인, 토큰 발급 등)의 대상이 됨:

* `status == UserStatus.ACTIVE`
* `enabled == true`

이를 코드 상에서 매번 조건으로 체크하는 대신, **Repository 쿼리에서 명시적으로 필터링**하는 방식이 명확하고 안전함.

---

### 💡 개선 사항

#### 🔸 Repository 메서드 추가

```java
@Query("SELECT u FROM User u WHERE u.email = :email AND u.status = 'ACTIVE' AND u.enabled = true")
Optional<User> findActiveUserByEmail(@Param("email") String email);
```

> 또는 메서드 네이밍 기반 선언 방식:

```java
Optional<User> findByEmailAndStatusAndEnabled(String email, User.UserStatus status, boolean enabled);
```

---

### 🎯 기대 효과

* **명시적인 의도 표현** → 비활성 사용자 제외 명확
* **보안성 향상** → 정지/비활성 사용자 대상 작업 방지
* **중복 코드 제거** → 서비스단에서 매번 조건 검사 불필요
* **성능 향상** → DB에서 조건 필터링으로 불필요한 데이터 조회 방지

---

### ✅ 적용 대상 서비스

* `RefreshTokenService` → 토큰 저장/검증/삭제 시
* `UserService` → 유저 페이지에서 유저 정보 조회 시
